### PR TITLE
feat: gh-dashの設定ファイルとエイリアスを追加

### DIFF
--- a/config.fish
+++ b/config.fish
@@ -85,3 +85,7 @@ function tmuxpopup -d "toggle tmux popup window"
     tmux display-popup -d '#{pane_current_path}' -xC -yC -w$width -h$height -E "tmux attach -t $popup_session || tmux new -s $popup_session"
   end
 end
+
+function dh --wraps='gh dash -c ~/dotfiles/gh-dash/config.yml' --description 'alias dash=gh dash -c ~/dotfiles/gh-dash/config.yml'
+  gh dash -c ~/dotfiles/gh-dash/config.yml $argv
+end

--- a/config.fish
+++ b/config.fish
@@ -89,3 +89,7 @@ end
 function dh --wraps='gh dash -c ~/dotfiles/gh-dash/config.yml' --description 'alias dash=gh dash -c ~/dotfiles/gh-dash/config.yml'
   gh dash -c ~/dotfiles/gh-dash/config.yml $argv
 end
+
+function wt-clean --description 'Remove all worktrees except main'
+  wt remove -f -y (wt list --format=json | jq -r '.[] | select(.is_main | not) | .branch')
+end

--- a/gh-dash/config.yml
+++ b/gh-dash/config.yml
@@ -84,10 +84,10 @@ keybindings:
         cd {{.RepoPath}}; tig
   prs:
     - key: C
-      name: code review
+      name: checkout on worktree
       command: >
         tmux new-window -n "PR-{{.PrNumber}}"
-        "wt switch pr:{{.PrNumber}} && claude '/pr-review {{.PrNumber}}'"
+        "wt switch pr:{{.PrNumber}}"
 
 theme:
   colors:

--- a/gh-dash/config.yml
+++ b/gh-dash/config.yml
@@ -1,0 +1,116 @@
+prSections:
+  - title: My Pull Requests
+    filters: is:open
+  - title: Needs My Review
+    filters: is:open review-requested:@me
+  - title: Involved
+    filters: is:open involves:@me -author:@me
+issuesSections:
+  - title: My Issues
+    filters: is:open author:@me
+  - title: Assigned
+    filters: is:open assignee:@me
+  - title: Involved
+    filters: is:open involves:@me -author:@me
+notificationsSections:
+  - title: All
+    filters: ""
+  - title: Created
+    filters: reason:author
+  - title: Participating
+    filters: reason:participating
+  - title: Mentioned
+    filters: reason:mention
+  - title: Review Requested
+    filters: reason:review-requested
+  - title: Assigned
+    filters: reason:assign
+  - title: Subscribed
+    filters: reason:subscribed
+  - title: Team Mentioned
+    filters: reason:team-mention
+repo:
+  branchesRefetchIntervalSeconds: 30
+  prsRefetchIntervalSeconds: 60
+defaults:
+  preview:
+    open: false
+    width: 70
+  prsLimit: 20
+  prApproveComment: LGTM
+  issuesLimit: 20
+  notificationsLimit: 20
+  view: prs
+  layout:
+    prs:
+      updatedAt:
+        width: 5
+      createdAt:
+        width: 5
+      repo:
+        width: 20
+      author:
+        width: 15
+      authorIcon:
+        hidden: false
+      assignees:
+        width: 20
+        hidden: true
+      base:
+        width: 15
+        hidden: true
+      lines:
+        width: 15
+    issues:
+      updatedAt:
+        width: 5
+      createdAt:
+        width: 5
+      repo:
+        width: 15
+      creator:
+        width: 10
+      creatorIcon:
+        hidden: false
+      assignees:
+        width: 20
+        hidden: true
+  refetchIntervalMinutes: 30
+keybindings:
+  universal:
+    - key: g
+      name: tig
+      command: >
+        cd {{.RepoPath}}; tig
+  prs:
+    - key: C
+      name: code review
+      command: >
+        tmux new-window -n "PR-{{.PrNumber}}"
+        "wt switch pr:{{.PrNumber}} && claude '/pr-review {{.PrNumber}}'"
+
+theme:
+  colors:
+    text:
+      primary: "#F7F1FF"
+      secondary: "#5AD4E6"
+      inverted: "#F7F1FF"
+      faint: "#3E4057"
+      warning: "#FC618D"
+      success: "#7BD88F"
+    background:
+      selected: "#535155"
+    border:
+      primary: "#948AE3"
+      secondary: "#7BD88F"
+      faint: "#3E4057"
+  ui:
+    sectionsShowCount: true
+    table:
+      showSeparator: true
+      compact: true
+pager:
+  diff: "diffnav"
+confirmQuit: false
+showAuthorIcons: true
+smartFilteringAtLaunch: true


### PR DESCRIPTION
## 概要
- gh-dash（GitHub Dashboard TUI）の設定ファイル（`gh-dash/config.yml`）を追加
- `dh` コマンドとしてfish shellのエイリアスを追加

## 変更内容
- `gh-dash/config.yml`: PR・Issue・通知のセクション設定、レイアウト、キーバインド（tig連携、claude PR reviewコマンド連携）、Monokai Proベースのテーマカラー設定
- `config.fish`: `dh` エイリアスを追加（`gh dash -c ~/dotfiles/gh-dash/config.yml` のラッパー）

## Jira
- N/A

## 動作確認
- [ ] `dh` コマンドでgh-dashが起動すること
- [ ] PR・Issue・通知の各セクションが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)