### PR TITLE
chore: UI表示サイズの拡大とgs関数の改善

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -84,8 +84,6 @@ set -g @tmux_power_theme 'sky'
 bind -n C-q run-shell "fish -c \"tmuxpopup\""
 bind t display-popup \
   -d "#{pane_current_path}" \
-  -w 80% \
-  -h 80% \
   -E "tig"
 
 run '~/.tmux/plugins/tpm/tpm'

--- a/claude/commands/memo.md
+++ b/claude/commands/memo.md
@@ -13,8 +13,7 @@ description: 今日の日報にメモや学びを追記する
 2. **日次エントリの存在確認**
    - `mcp__dailymemo__get_report` で該当日付の日次エントリが存在するか確認
    - 日次エントリが存在しない場合（"Day entry for {date} not found in monthly report" エラー）:
-     - ユーザーに「{日付}の日次エントリが存在しません。新規作成してもよいですか？」と確認
-     - ユーザーが承諾した場合のみ `mcp__dailymemo__create_daily_report` で作成（`sections` パラメータで「本日の作業内容」「メモ」をデフォルトセクションとして指定）
+     - 確認なしで `mcp__dailymemo__create_daily_report` で作成（`sections` パラメータで「本日の作業内容」「メモ」をデフォルトセクションとして指定）
 
 3. **メモの追記**
    - 日報の内容を確認し、追記内容に最も適したセクションを選択

--- a/config.fish
+++ b/config.fish
@@ -45,7 +45,11 @@ function gf --wraps='git fetch -p' --description 'alias gf=git fetch -p'
 end
 
 function gs --wraps='git switch' --description 'alias gs=git switch'
-  git switch $argv; 
+  if test (count $argv) -eq 0
+    git branch --format='%(refname:short)' | fzf | xargs -r git switch
+  else
+    git switch $argv
+  end
 end
 
 function pull --description 'alias pull=git pull'

--- a/config.fish
+++ b/config.fish
@@ -73,8 +73,8 @@ function cc --wraps=claude --description 'alias cc=claude'
 end
 
 function tmuxpopup -d "toggle tmux popup window"
-  set width '80%'
-  set height '80%'
+  set width '90%'
+  set height '90%'
   set session (tmux display-message -p -F "#{session_name}")
   set current_dir (basename (tmux display-message -p -F "#{pane_current_path}"))
   set popup_session "popup_$current_dir"

--- a/gh-dash/config.yml
+++ b/gh-dash/config.yml
@@ -87,7 +87,7 @@ keybindings:
       name: checkout on worktree
       command: >
         tmux new-window -n "PR-{{.PrNumber}}"
-        "wt switch pr:{{.PrNumber}}"
+        "wt switch pr:{{.PrNumber}} && $SHELL"
 
 theme:
   colors:

--- a/gh-dash/config.yml
+++ b/gh-dash/config.yml
@@ -95,7 +95,7 @@ theme:
       primary: "#F7F1FF"
       secondary: "#5AD4E6"
       inverted: "#F7F1FF"
-      faint: "#3E4057"
+      faint: "#a9b1d6"
       warning: "#FC618D"
       success: "#7BD88F"
     background:

--- a/nvim/lua/plugins/telescope.lua
+++ b/nvim/lua/plugins/telescope.lua
@@ -27,14 +27,15 @@ return {
           },
         },
 
+        layout_strategy = "vertical",
         layout_config = {
-          horizontal = {
+          vertical = {
             preview_width = 0.55,
             results_width = 0.8,
           },
-          width = 0.85,
-          height = 0.80,
-          preview_cutoff = 120,
+          width = 0.95,
+          height = 0.9,
+          preview_cutoff = 10,
         },
       },
 

--- a/nvim/lua/plugins/ui.lua
+++ b/nvim/lua/plugins/ui.lua
@@ -47,6 +47,20 @@ return {
     end
   },
 
+  -- 通知
+  {
+    "rcarriga/nvim-notify",
+    event = "VeryLazy",
+    config = function()
+      local notify = require("notify")
+      notify.setup({
+        stages = "fade_in_slide_out",
+        timeout = 3000,
+      })
+      vim.notify = notify
+    end,
+  },
+
   -- status line
   {
     'nvim-lualine/lualine.nvim',


### PR DESCRIPTION
## 概要

- telescope のレイアウトを vertical に変更し、表示サイズを拡大
- tmux popup のサイズを 80% → 90% に拡大、tig の popup サイズ指定を削除
- `gs` コマンドを引数なしで実行した場合、fzf でブランチ選択できるように改善
- 日報エントリ追加時のユーザー確認ステップを削除
- nvim-notify プラグインを追加（フェードイン・スライドアウトの通知表示）
- gh-dash の faint カラーを視認性向上のため変更
- gh-dash の worktree 切り替え後にセッションが切れる問題を修正（`$SHELL` を追加）

## Jira チケット

- N/A

## 動作確認

- [ ] `gs` を引数なしで実行し、fzf でブランチ選択・切り替えができること
- [ ] `gs <branch>` で従来通り切り替えできること
- [ ] tmux popup が 90% サイズで表示されること
- [ ] telescope が vertical レイアウトで表示されること
- [ ] nvim で通知が nvim-notify 経由で表示されること
- [ ] gh-dash で worktree 切り替え後にシェルセッションが維持されること
- [ ] gh-dash の表示色が適切であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)