### PR TITLE
chore: nvim-notifyからnoice.nvimに移行しUI強化

### DIFF
--- a/nvim/lua/plugins/ui.lua
+++ b/nvim/lua/plugins/ui.lua
@@ -47,18 +47,51 @@ return {
     end,
   },
 
-  -- 通知
+  -- コマンドライン・メッセージ・通知のUI強化
   {
-    "rcarriga/nvim-notify",
+    "folke/noice.nvim",
     event = "VeryLazy",
-    config = function()
-      local notify = require("notify")
-      notify.setup({
-        stages = "fade_in_slide_out",
-        timeout = 3000,
-      })
-      vim.notify = notify
-    end,
+    dependencies = {
+      "MunifTanjim/nui.nvim",
+      "rcarriga/nvim-notify",
+    },
+    opts = {
+      notify = {
+        enabled = true,
+        view = "notify",
+      },
+      views = {
+        cmdline_popup = {
+          position = {
+            row = "40%",
+            col = "50%",
+          },
+          size = {
+            width = 60,
+            height = "auto",
+          },
+          border = {
+            style = "rounded",
+            padding = { 0, 1 },
+          },
+        },
+        popupmenu = {
+          relative = "editor",
+          position = {
+            row = "40%",
+            col = "50%",
+          },
+          size = {
+            width = 60,
+            height = 10,
+          },
+          border = {
+            style = "rounded",
+            padding = { 0, 1 },
+          },
+        },
+      },
+    },
   },
 
   -- status line


### PR DESCRIPTION
## 概要
- nvim-notifyの単体利用からnoice.nvimに移行し、コマンドライン・メッセージ・通知のUIを統合的に強化

## 変更内容
- `rcarriga/nvim-notify` の単体設定を削除し、`folke/noice.nvim` を導入
- noice.nvimの依存として `nui.nvim` と `nvim-notify` を設定
- コマンドラインポップアップとポップアップメニューのUIカスタマイズ（中央配置、角丸ボーダー）

## Jiraチケット
- N/A

## 動作確認
- [ ] Neovimを起動し、コマンドライン（`:` 入力時）が中央にポップアップ表示されること
- [ ] 通知が正常に表示されること
- [ ] エラーや警告が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)